### PR TITLE
Fix NWAPI fuckery

### DIFF
--- a/VPNGuard/EventHandlers.cs
+++ b/VPNGuard/EventHandlers.cs
@@ -19,7 +19,7 @@ namespace VPNGuard
             Plugin.Singleton.VerboseLog($"{userid} from {ipAddress} ({country}) is preauthenticating!");
 
             //Let Northwood Staff bypass checks.
-            if (flags == CentralAuthPreauthFlags.NorthwoodStaff)
+            if (flags.HasFlag(CentralAuthPreauthFlags.NorthwoodStaff))
             {
                 Plugin.Singleton.VerboseLog($"{userid} from {ipAddress} ({country}) is Northwood Staff. Bypassing account / VPN checks...");
                 return PreauthCancellationData.Accept();
@@ -55,7 +55,7 @@ namespace VPNGuard
             Plugin.Singleton.VerboseLog($"{player.UserId} from {player.IpAddress} has joined the game.");
 
             //Let Northwood Staff bypass checks.
-            if (player.IsNorthwoodStaff)
+            if (player.IsNorthwoodStaff || player.UserId.EndsWith("@northwood"))
             {
                 Plugin.Singleton.VerboseLog($"{player.UserId} from {player.IpAddress} is Northwood Staff. Bypassing account / VPN checks...");
 

--- a/VPNGuard/Plugin.cs
+++ b/VPNGuard/Plugin.cs
@@ -23,7 +23,7 @@ namespace VPNGuard
         //Dicrionary containing all UserIDs loaded from file.
         public static Dictionary<string, VPNGuardUserId> UserIds = new Dictionary<string, VPNGuardUserId>();
 
-        [PluginEntryPoint("VPNGuard", "1.0.0.0", "A VPN blocking plugin for SCP: SL servers running NWAPI.", "SomewhatSane#0979")]
+        [PluginEntryPoint("VPNGuard", "1.0.1.0", "A VPN blocking plugin for SCP: SL servers running NWAPI.", "SomewhatSane#0979")]
         private void LoadPlugin()
         {
             Handler = PluginHandler.Get(this);


### PR DESCRIPTION
flags need .HasFlag() or .HasFlagFast() in order to check for a specific flag. Otherwise, if they have multiple flags, == will always be false.

Also NWAPI does not properly set player.IsNorthwoodStaff, so until it is fixed, I've added a check for using a NW userID instead.